### PR TITLE
Fix dependencies problem with Grails 2.0.2

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,6 +1,6 @@
 #Grails Metadata file
-#Fri Jan 13 09:51:09 CET 2012
-app.grails.version=2.0.0
+#Mon Apr 02 19:48:23 CEST 2012
+app.grails.version=2.0.2
 app.name=grails-hibernate-search-plugin
-plugins.hibernate=2.0.0
+plugins.hibernate=2.0.2
 plugins.svn=1.0.0.M1

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -18,7 +18,9 @@ grails.project.dependency.resolution = {
     }
 
     dependencies {
-        compile('org.hibernate:hibernate-search:3.4.1.Final')
+        compile('org.hibernate:hibernate-search:3.4.1.Final') {
+            excludes "hibernate-core"
+        }
     }
 
     plugins {


### PR DESCRIPTION
Hi,

upgrading to Grails 2.0.2 I'm facing an error with an unresolved dependency (hibernate 3.6.10) this fix worked for me.

ciao
stefano
