### PR TITLE
ability to define 'depth' param for @IndexEmbedded

### DIFF
--- a/src/groovy/org/codehaus/groovy/grails/plugins/hibernate/search/SearchMappingConfigurableLocalSessionFactoryBean.groovy
+++ b/src/groovy/org/codehaus/groovy/grails/plugins/hibernate/search/SearchMappingConfigurableLocalSessionFactoryBean.groovy
@@ -124,10 +124,12 @@ class SearchMappingConfigurableLocalSessionFactoryBean extends ConfigurableLocal
 
             currentMapping = currentMapping.property(name, ElementType.FIELD).indexEmbedded()
 
-            def depth = args.indexEmbedded["depth"]
+            if ( args.indexEmbedded != true ) {
+                def depth = args.indexEmbedded["depth"]
 
-            if ( depth ) {
-                currentMapping = currentMapping.depth(depth)
+                if ( depth ) {
+                    currentMapping = currentMapping.depth(depth)
+                }
             }
         } else if ( args.containedIn ) {
 


### PR DESCRIPTION
for circular references, e.g.:

yourColumnName(indexEmbedded: ['depth': 2])
